### PR TITLE
stdenv: pURL docu enhancements & list interface

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -652,6 +652,9 @@
   "var-meta-identifiers-purlParts": [
     "index.html#var-meta-identifiers-purlParts"
   ],
+  "var-meta-identifiers-purls": [
+    "index.html#var-meta-identifiers-purls"
+  ],
   "var-meta-teams": [
     "index.html#var-meta-teams"
   ],

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -176,7 +176,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Metadata identifier pURL (https://github.com/package-url/purl-spec) has been added, which enables a reliable identification and locatization of software packages. Maintainers can rely on the `drv.src` default identifier or may check their `drv.meta.identifiers.v1.purl` for completeness.
+- Metadata identifier purl (Package URL, https://github.com/package-url/purl-spec) has been added for fetchgit, fetchpypi and fetchFromGithub fetchers and derivations for Perl, Python and Ruby derivations have been adjusted to reuse these informations. Package URL's enables a reliable identification and locatization of software packages. Maintainers should rely on the `drv.src.meta.identifiers.v1.purl` default identifier and can enhance their `drv.meta.identifiers.v1.purls` list once they would like to have additional identifiers.
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -176,7 +176,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Metadata identifier pURL (https://github.com/package-url/purl-spec) has been added, which enables a SBOM generation. Maintainers are urged to check their `drv.meta.identifiers.v1.purl` for completeness.
+- Metadata identifier pURL (https://github.com/package-url/purl-spec) has been added, which enables a reliable identification and locatization of software packages. Maintainers can rely on the `drv.src` default identifier or may check their `drv.meta.identifiers.v1.purl` for completeness.
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -324,7 +324,7 @@ A readonly attribute containing the list of guesses for what CPE for this packag
 
 [Package URL](https://github.com/package-url/purl-spec) (pURL) is a specification to reliably identify and locate software packages. Through identification of software packages, additional (non-major) use cases are e.g. software license cross-verification via third party databases or initial vulnerability response management. Package URL's default to the mkDerivation.src, as the original consumed software package is the single point of truth.
 
-#### `meta.identifiers.purlParts` {#var-meta-identifiers-purlParts}
+#### `meta.identifiers.pURLparts` {#var-meta-identifiers-pURLparts}
 
 This attribute contains an attribute set of all parts of the pURL for this package.
 
@@ -335,6 +335,6 @@ This attribute contains an attribute set of all parts of the pURL for this packa
 
 A readonly attribute which is built based on purlParts. It is the main identifier, consumers should consider using the purls list interface to be prepared for edge cases.
 
-#### `meta.identifiers.purls` {#var-meta-identifiers-purls}
+#### `meta.identifiers.pURLs` {#var-meta-identifiers-purls}
 
 A readonly attribute list which defaults to a single main package URL element. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -337,4 +337,4 @@ A readonly attribute which is built based on purlParts. It is the main identifie
 
 #### `meta.identifiers.purls` {#var-meta-identifiers-purls}
 
-A readonly attribute list which defaults to a single element equal to the main package URL. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).
+A readonly attribute list which defaults to a single element equal to the main pURL. It provides an interface for additional identifiers of mkDerivation.src and / or vendored dependencies inside mkDerivation.src, which maintainers can decide to use on top. Identifiers different to the default src identifier are not recommended by default as they might cause maintenance overhead or may diverge (e.g. differences between source distribution pkg:github and binary distribution like pkg:pypi).

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -337,4 +337,4 @@ A readonly attribute which is built based on purlParts. It is the main identifie
 
 #### `meta.identifiers.purls` {#var-meta-identifiers-purls}
 
-A readonly attribute list which defaults to mainPURL. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).
+A readonly attribute list which defaults to a single main package URL element. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -322,7 +322,7 @@ A readonly attribute containing the list of guesses for what CPE for this packag
 
 ### Package URL {#sec-meta-identifiers-purl}
 
-[Package URL](https://github.com/package-url/purl-spec) (pURL) is a specification to reliably identify and locate software packages.
+[Package URL](https://github.com/package-url/purl-spec) (pURL) is a specification to reliably identify and locate software packages. Through identification of software packages, additional (non-major) use cases are e.g. software license cross-verification via third party databases or initial vulnerability response management. Package URL's default to the mkDerivation.src, as the original consumed software package is the single point of truth.
 
 #### `meta.identifiers.purlParts` {#var-meta-identifiers-purlParts}
 
@@ -331,6 +331,10 @@ This attribute contains an attribute set of all parts of the pURL for this packa
 * `type` mandatory [type](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/docs/standard/summary.md) which needs to be provided
 * `spec` specify the pURL in accordance with the [purl-spec](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/purl-specification.md)
 
-#### `meta.identifiers.purl` {#var-meta-identifiers-purl}
+#### `meta.identifiers.pURL` {#var-meta-identifiers-purl}
 
-A readonly attribute which is built based on purlParts.
+A readonly attribute which is built based on purlParts. It is the main identifier, consumers should consider using the purls list interface to be prepared for edge cases.
+
+#### `meta.identifiers.purls` {#var-meta-identifiers-purls}
+
+A readonly attribute list which defaults to mainPURL. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -324,17 +324,17 @@ A readonly attribute containing the list of guesses for what CPE for this packag
 
 [Package URL](https://github.com/package-url/purl-spec) (pURL) is a specification to reliably identify and locate software packages. Through identification of software packages, additional (non-major) use cases are e.g. software license cross-verification via third party databases or initial vulnerability response management. Package URL's default to the mkDerivation.src, as the original consumed software package is the single point of truth.
 
-#### `meta.identifiers.pURLparts` {#var-meta-identifiers-pURLparts}
+#### `meta.identifiers.purlParts` {#var-meta-identifiers-purlParts}
 
 This attribute contains an attribute set of all parts of the pURL for this package.
 
 * `type` mandatory [type](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/docs/standard/summary.md) which needs to be provided
 * `spec` specify the pURL in accordance with the [purl-spec](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/purl-specification.md)
 
-#### `meta.identifiers.pURL` {#var-meta-identifiers-purl}
+#### `meta.identifiers.purl` {#var-meta-identifiers-purl}
 
-A readonly attribute which is built based on purlParts. It is the main identifier, consumers should consider using the purls list interface to be prepared for edge cases.
+A readonly attribute which is built based on purlParts. It is the main identifier, consumers should consider using the pURL's list interface to be prepared for edge cases.
 
-#### `meta.identifiers.pURLs` {#var-meta-identifiers-purls}
+#### `meta.identifiers.purls` {#var-meta-identifiers-purls}
 
-A readonly attribute list which defaults to a single main package URL element. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).
+A readonly attribute list which defaults to a single element equal to the main package URL. It can get enhanced through additional package URL's by maintainers and may provide an interface for additional identifiers or vendored dependencies inside mkDerivation.src. Identifiers different to the src identifier are not recommended by default as they might diverge (e.g. differences between source distribution pkg:github and binary distribution pkg:pypi).

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -337,4 +337,4 @@ A readonly attribute which is built based on purlParts. It is the main identifie
 
 #### `meta.identifiers.purls` {#var-meta-identifiers-purls}
 
-A readonly attribute list which defaults to a single element equal to the main pURL. It provides an interface for additional identifiers of mkDerivation.src and / or vendored dependencies inside mkDerivation.src, which maintainers can decide to use on top. Identifiers different to the default src identifier are not recommended by default as they might cause maintenance overhead or may diverge (e.g. differences between source distribution pkg:github and binary distribution like pkg:pypi).
+A readonly attribute list which defaults to a single element equal to the main pURL. It provides an interface for additional identifiers of mkDerivation.src and / or vendored dependencies inside mkDerivation.src, which maintainers can conciously decide to use on top. Identifiers different to the default src identifier are not recommended by default as they might cause maintenance overhead or may diverge (e.g. differences between source distribution pkg:github and binary distribution like pkg:pypi).

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -719,12 +719,14 @@ let
 
           purlParts = attrs.meta.identifiers.purlParts or { };
           purl = if hasAllPURLParts purlParts then "pkg:${purlParts.type}/${purlParts.spec}" else null;
+          purls = optional (purl != null) purl;
 
           v1 = {
             inherit
               cpeParts
               possibleCPEs
               purlParts
+              purls
               ;
             ${if cpe != null then "cpe" else null} = cpe;
             ${if purl != null then "purl" else null} = purl;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
