### PR TITLE
Appendix: NixOS VM test(s) to validate the new `includeNixDBHostSignatures` option

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -90,7 +90,7 @@ let
   imageWithoutSigs = pkgs.dockerTools.buildImage {
     name = "image-without-sigs";
     tag = "latest";
-    contents = [
+    copyToRoot = [
       pkgs.nix
       pkgs.hello
     ];
@@ -101,7 +101,7 @@ let
   imageWithSigs = pkgs.dockerTools.buildImage {
     name = "image-with-sigs";
     tag = "latest";
-    contents = [
+    copyToRoot = [
       pkgs.nix
       pkgs.hello
     ];

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -86,6 +86,22 @@ let
       ];
     };
   };
+
+  imageWithSigs = pkgs.dockerTools.buildImage {
+    name = "image-with-sigs";
+    tag = "latest";
+    contents = [ pkgs.hello ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = true;
+  };
+
+  imageWithoutSigs = pkgs.dockerTools.buildImage {
+    name = "image-without-sigs";
+    tag = "latest";
+    contents = [ pkgs.hello ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = false;
+  };
 in
 {
   name = "docker-tools";

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -102,6 +102,22 @@ let
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };
+
+  layeredImageWithoutSigs = pkgs.dockerTools.streamLayeredImage {
+    name = "layered-image-without-sigs";
+    tag = "latest";
+    contents = [ pkgs.hello ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = false;
+  };
+
+  layeredImageWithSigs = pkgs.dockerTools.streamLayeredImage {
+    name = "layered-image-with-sigs";
+    tag = "latest";
+    contents = [ pkgs.hello ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = true;
+  };
 in
 {
   name = "docker-tools";
@@ -616,13 +632,22 @@ in
         )
     
     with subtest("includeNixDBHostSignatures copies host signatures"):
-        docker.succeed("docker load --input='${imageWithoutSigs}'")
-        docker.succeed("docker run --rm ${imageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
-        docker.succeed("docker rmi ${imageWithoutSigs.imageName}")
+        with subtest("for buildImage"):
+            docker.succeed("docker load --input='${imageWithoutSigs}'")
+            docker.succeed("docker run --rm ${imageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("docker rmi ${imageWithoutSigs.imageName}")
 
-        docker.succeed("docker load --input='${imageWithSigs}'")
-        docker.succeed("docker run --rm ${imageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
-        docker.succeed("docker rmi ${imageWithSigs.imageName}")
+            docker.succeed("docker load --input='${imageWithSigs}'")
+            docker.succeed("docker run --rm ${imageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("docker rmi ${imageWithSigs.imageName}")
 
+        with subtest("for streamLayeredImage"):
+            docker.succeed("${layeredImageWithoutSigs} | docker load")
+            docker.succeed("docker run --rm ${layeredImageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("docker rmi ${layeredImageWithoutSigs.imageName}")
+
+            docker.succeed("${layeredImageWithSigs} | docker load")
+            docker.succeed("docker run --rm ${layeredImageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("docker rmi ${layeredImageWithSigs.imageName}")
   '';
 }

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -130,6 +130,10 @@ let
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };
+
+  signingKeyForSignatureTests = pkgs.runCommand "signingKey" { } ''
+    ${pkgs.nix}/bin/nix-store --generate-binary-cache-key key $out /dev/null
+  '';
 in
 {
   name = "docker-tools";
@@ -148,6 +152,8 @@ in
           diskSize = 3072;
           docker.enable = true;
         };
+
+        nix.settings.secret-key-files = signingKeyForSignatureTests;
       };
   };
 

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -90,7 +90,10 @@ let
   imageWithoutSigs = pkgs.dockerTools.buildImage {
     name = "image-without-sigs";
     tag = "latest";
-    contents = [ pkgs.nix pkgs.hello ];
+    contents = [
+      pkgs.nix
+      pkgs.hello
+    ];
     includeNixDB = true;
     includeNixDBHostSignatures = false;
   };
@@ -98,7 +101,10 @@ let
   imageWithSigs = pkgs.dockerTools.buildImage {
     name = "image-with-sigs";
     tag = "latest";
-    contents = [ pkgs.nix pkgs.hello ];
+    contents = [
+      pkgs.nix
+      pkgs.hello
+    ];
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };
@@ -106,7 +112,10 @@ let
   layeredImageWithoutSigs = pkgs.dockerTools.streamLayeredImage {
     name = "layered-image-without-sigs";
     tag = "latest";
-    contents = [ pkgs.nix pkgs.hello ];
+    contents = [
+      pkgs.nix
+      pkgs.hello
+    ];
     includeNixDB = true;
     includeNixDBHostSignatures = false;
   };
@@ -114,7 +123,10 @@ let
   layeredImageWithSigs = pkgs.dockerTools.streamLayeredImage {
     name = "layered-image-with-sigs";
     tag = "latest";
-    contents = [ pkgs.nix pkgs.hello ];
+    contents = [
+      pkgs.nix
+      pkgs.hello
+    ];
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -642,7 +642,7 @@ in
             "${nonRootTestImage} | docker load",
             "docker run --rm ${chownTestImage.imageName} | diff /dev/stdin <(echo 12345:12345)"
         )
-    
+
     with subtest("includeNixDBHostSignatures allows store verification"):
         with subtest("for buildImage"):
             docker.succeed("${imageWithoutSigs} | docker load")

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -90,7 +90,7 @@ let
   imageWithoutSigs = pkgs.dockerTools.buildImage {
     name = "image-without-sigs";
     tag = "latest";
-    contents = [ pkgs.hello ];
+    contents = [ pkgs.nix pkgs.hello ];
     includeNixDB = true;
     includeNixDBHostSignatures = false;
   };
@@ -98,7 +98,7 @@ let
   imageWithSigs = pkgs.dockerTools.buildImage {
     name = "image-with-sigs";
     tag = "latest";
-    contents = [ pkgs.hello ];
+    contents = [ pkgs.nix pkgs.hello ];
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };
@@ -106,7 +106,7 @@ let
   layeredImageWithoutSigs = pkgs.dockerTools.streamLayeredImage {
     name = "layered-image-without-sigs";
     tag = "latest";
-    contents = [ pkgs.hello ];
+    contents = [ pkgs.nix pkgs.hello ];
     includeNixDB = true;
     includeNixDBHostSignatures = false;
   };
@@ -114,7 +114,7 @@ let
   layeredImageWithSigs = pkgs.dockerTools.streamLayeredImage {
     name = "layered-image-with-sigs";
     tag = "latest";
-    contents = [ pkgs.hello ];
+    contents = [ pkgs.nix pkgs.hello ];
     includeNixDB = true;
     includeNixDBHostSignatures = true;
   };
@@ -631,23 +631,23 @@ in
             "docker run --rm ${chownTestImage.imageName} | diff /dev/stdin <(echo 12345:12345)"
         )
     
-    with subtest("includeNixDBHostSignatures copies host signatures"):
+    with subtest("includeNixDBHostSignatures allows store verification"):
         with subtest("for buildImage"):
-            docker.succeed("docker load --input='${imageWithoutSigs}'")
-            docker.succeed("docker run --rm ${imageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("${imageWithoutSigs} | docker load")
+            docker.fail("docker run --rm ${imageWithoutSigs.imageName} ${pkgs.nix}/bin/nix store verify --all --sigs-needed 1")
             docker.succeed("docker rmi ${imageWithoutSigs.imageName}")
 
-            docker.succeed("docker load --input='${imageWithSigs}'")
-            docker.succeed("docker run --rm ${imageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("${imageWithSigs} | docker load")
+            docker.succeed("docker run --rm ${imageWithSigs.imageName} ${pkgs.nix}/bin/nix store verify --all --sigs-needed 1")
             docker.succeed("docker rmi ${imageWithSigs.imageName}")
 
         with subtest("for streamLayeredImage"):
             docker.succeed("${layeredImageWithoutSigs} | docker load")
-            docker.succeed("docker run --rm ${layeredImageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.fail("docker run --rm ${layeredImageWithoutSigs.imageName} ${pkgs.nix}/bin/nix store verify --all --sigs-needed 1")
             docker.succeed("docker rmi ${layeredImageWithoutSigs.imageName}")
 
             docker.succeed("${layeredImageWithSigs} | docker load")
-            docker.succeed("docker run --rm ${layeredImageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
+            docker.succeed("docker run --rm ${layeredImageWithSigs.imageName} ${pkgs.nix}/bin/nix store verify --all --sigs-needed 1")
             docker.succeed("docker rmi ${layeredImageWithSigs.imageName}")
   '';
 }

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -87,20 +87,20 @@ let
     };
   };
 
-  imageWithSigs = pkgs.dockerTools.buildImage {
-    name = "image-with-sigs";
-    tag = "latest";
-    contents = [ pkgs.hello ];
-    includeNixDB = true;
-    includeNixDBHostSignatures = true;
-  };
-
   imageWithoutSigs = pkgs.dockerTools.buildImage {
     name = "image-without-sigs";
     tag = "latest";
     contents = [ pkgs.hello ];
     includeNixDB = true;
     includeNixDBHostSignatures = false;
+  };
+
+  imageWithSigs = pkgs.dockerTools.buildImage {
+    name = "image-with-sigs";
+    tag = "latest";
+    contents = [ pkgs.hello ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = true;
   };
 in
 {
@@ -614,5 +614,15 @@ in
             "${nonRootTestImage} | docker load",
             "docker run --rm ${chownTestImage.imageName} | diff /dev/stdin <(echo 12345:12345)"
         )
+    
+    with subtest("includeNixDBHostSignatures copies host signatures"):
+        docker.succeed("docker load --input='${imageWithoutSigs}'")
+        docker.succeed("docker run --rm ${imageWithoutSigs.imageName} sh -c 'test -z \"$(ls -A /nix/var/nix/db/sigs)\"'")
+        docker.succeed("docker rmi ${imageWithoutSigs.imageName}")
+
+        docker.succeed("docker load --input='${imageWithSigs}'")
+        docker.succeed("docker run --rm ${imageWithSigs.imageName} sh -c 'test -n \"$(ls -A /nix/var/nix/db/sigs)\"'")
+        docker.succeed("docker rmi ${imageWithSigs.imageName}")
+
   '';
 }

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -76,6 +76,10 @@ let
       ${buildPackages.nix}/bin/nix-store --load-db < ${
         closureInfo { rootPaths = contentsList; }
       }/registration
+      mkdir -p nix/var/nix/gcroots/docker/
+      for i in ${lib.concatStringsSep " " contentsList}; do
+      ln -s $i nix/var/nix/gcroots/docker/$(basename $i)
+      done;
       ${lib.optionalString includeNixDBHostSignatures ''
         # copy signatures from building system (-s "local?read-only=true") into "NIX_REMOTE=local?root=$PWD"
         # readonly store is required to avoid write operations which might fail due to missing privileges
@@ -83,11 +87,6 @@ let
       ''}
       # Reset registration times to make the image reproducible
       ${buildPackages.sqlite}/bin/sqlite3 nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"
-
-      mkdir -p nix/var/nix/gcroots/docker/
-      for i in ${lib.concatStringsSep " " contentsList}; do
-      ln -s $i nix/var/nix/gcroots/docker/$(basename $i)
-      done;
     '';
 
   # The OCI Image specification recommends that configurations use values listed

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -79,7 +79,7 @@ let
       ${lib.optionalString includeNixDBHostSignatures ''
         # copy signatures from building system (-s "local?read-only=true") into "NIX_REMOTE=local?root=$PWD"
         # readonly store is required to avoid write operations which might fail due to missing privileges
-        ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store
+        NIX_STATE_DIR=$PWD/nix/var/nix ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store
       ''}
       # Reset registration times to make the image reproducible
       ${buildPackages.sqlite}/bin/sqlite3 nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -79,7 +79,7 @@ let
       ${lib.optionalString includeNixDBHostSignatures ''
         # copy signatures from building system (-s "local?read-only=true") into "NIX_REMOTE=local?root=$PWD"
         # readonly store is required to avoid write operations which might fail due to missing privileges
-        NIX_STATE_DIR=$PWD/nix/var/nix ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store --extra-experimental-features nix-command
+        ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store --extra-experimental-features nix-command
       ''}
       # Reset registration times to make the image reproducible
       ${buildPackages.sqlite}/bin/sqlite3 nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -79,7 +79,7 @@ let
       ${lib.optionalString includeNixDBHostSignatures ''
         # copy signatures from building system (-s "local?read-only=true") into "NIX_REMOTE=local?root=$PWD"
         # readonly store is required to avoid write operations which might fail due to missing privileges
-        NIX_STATE_DIR=$PWD/nix/var/nix ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store
+        NIX_STATE_DIR=$PWD/nix/var/nix ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store --extra-experimental-features nix-command
       ''}
       # Reset registration times to make the image reproducible
       ${buildPackages.sqlite}/bin/sqlite3 nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Added a NixOS VM test to validate the new `includeNixDBHostSignatures` option for both `dockerTools.buildImage` and `dockerTools.streamLayeredImage`.

> [!NOTE]
> Do we need both (buildImage & streamLayeredImage) tests?

The test itself implements the following logic:
* It defines two pairs of distinct Docker images using `pkgs.nix` and `pkgs.hello` as content:
    * A **control image** built with `includeNixDBHostSignatures = false`.
    * A **test image** built with `includeNixDBHostSignatures = true`.
* Including `pkgs.nix` makes the `nix` command-line tool available inside the container for verification.
* Within the VM test environment, it loads each image and attempts to verify the integrity of the entire Nix store using its signatures.
* It asserts that for the **control image** (without signatures), the command `nix store verify --all --sigs-needed 1` **fails**, as expected.
* It then asserts that for the **test image** (with signatures), the same command **succeeds**, confirming that the host's signatures were correctly copied and are usable by Nix.